### PR TITLE
update de.po (GNOME42-44)

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -9,14 +9,14 @@ msgstr ""
 "Project-Id-Version: battery-health-charging\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-12-22 00:07-0800\n"
-"PO-Revision-Date: 2024-04-19 16:04-0700\n"
+"PO-Revision-Date: 2025-03-09 10:10+0100\n"
 "Last-Translator: \n"
 "Language-Team: German\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Poedit 3.2.2\n"
 
 #: lib/notifier.js:29
 msgid "Battery Health Charging"
@@ -60,11 +60,11 @@ msgstr ""
 
 #: lib/notifier.js:79
 msgid "Install check failed."
-msgstr ""
+msgstr "Installationsprüfung fehlgeschlagen."
 
 #: lib/notifier.js:83
 msgid "Install check timed out."
-msgstr ""
+msgstr "Zeitüberschreitung bei der Installationsprüfung."
 
 #: lib/notifier.js:87
 #, javascript-format
@@ -74,17 +74,17 @@ msgstr "Battery Health Charging ist auf ein Problem gestoßen. (%s)"
 #: lib/notifier.js:91
 #, javascript-format
 msgid "Charging threshold not updated. (%s)"
-msgstr "Schwelle zum Stoppen des Batterieladens. (%s)"
+msgstr "Batterieladeschwelle nicht festgelegt. (%s)"
 
 #: lib/notifier.js:95
 #, javascript-format
 msgid "Threshold update process timed out. (%s)"
-msgstr ""
+msgstr "Zeitüberschreitung beim Festlegen des Schwellenwertes. (%s)"
 
 #: lib/notifier.js:99
 msgid "Apply correct Bios Password to set threshold."
 msgstr ""
-"Wenden Sie das richtige BIOS-Passwort an, um den Schwellenwert einzustellen."
+"Verwenden Sie das richtige BIOS-Passwort, um den Schwellenwert festzulegen."
 
 #: lib/notifier.js:103
 #, javascript-format
@@ -92,7 +92,7 @@ msgid ""
 "Battery 1\n"
 "Charge thresholds are set to %d / %d %%"
 msgstr ""
-"Batterie 1\n"
+"Akku 1\n"
 "Batterieladeschwellen: %d / %d %%"
 
 #. TRANSLATORS: Keep translation short if possible. Maximum  34 characters can be displayed here
@@ -107,7 +107,7 @@ msgid ""
 "Battery 1\n"
 "Charging Limit is set to %d%%"
 msgstr ""
-"Batterie 1\n"
+"Akku 1\n"
 "Batterieladeschwelle: %d%%"
 
 #. TRANSLATORS: Keep translation short if possible. Maximum  34 characters can be displayed here
@@ -122,7 +122,7 @@ msgid ""
 "Battery 2\n"
 "Charge thresholds are set to %d / %d %%"
 msgstr ""
-"Batterie 2\n"
+"Akku 2\n"
 "Batterieladeschwellen: %d / %d %%"
 
 #: lib/notifier.js:126
@@ -131,34 +131,37 @@ msgid ""
 "Battery 2\n"
 "Charging Limit is set to %d%%"
 msgstr ""
-"Batterie 2\n"
+"Akku 2\n"
 "Batterieladeschwelle: %d%%"
 
 #: lib/notifier.js:131
 msgid "Charging Mode is set to Full Capacity"
-msgstr "Lademodus ist auf Volle Kapazität gesetzt"
+msgstr "Lademodus ist auf Volle Kapazität festgelegt"
 
 #: lib/notifier.js:135
 msgid "Charging Mode is set to Balanced"
-msgstr "Lademodus ist auf Ausgeglichen gesetzt"
+msgstr "Lademodus ist auf Ausgeglichen festgelegt"
 
 #: lib/notifier.js:139
 msgid "Charging Mode is set to Maximum Lifespan"
-msgstr "Lademodus ist auf Maximale Lebensdauer gesetzt"
+msgstr "Lademodus ist auf Maximale Lebensdauer festgelegt"
 
 #: lib/notifier.js:143
 msgid "Charging Mode is set to Express"
-msgstr "Lademodus ist auf Express gesetzt"
+msgstr "Lademodus ist auf Express festgelegt"
 
 #: lib/notifier.js:147
 msgid "Charging Mode is set to Adaptive"
-msgstr "Lademodus ist auf Anpassungsfähig gesetzt"
+msgstr "Lademodus ist auf Anpassungsfähig festgelegt"
 
 #: lib/notifier.js:151
 msgid ""
 "Threshold not applied: Battery level above 75%. Please unplug the charger "
 "and discharge the battery below 75% to apply the 80% limit."
 msgstr ""
+"Schwellenwert nicht festgelegt: Ladestand über 75%. Bitte Netzstecker "
+"entfernen und den Akku auf unter 75% entladen, um die Schwelle von 80% "
+"festzulegen."
 
 #: lib/powerIcon42.js:134 lib/powerIcon.js:116 lib/powerIcon.js:122
 #, javascript-format
@@ -213,7 +216,7 @@ msgstr "Express"
 #. TRANSLATORS: Keep translation short if possible. Maximum  34 characters can be displayed here
 #: lib/thresholdPanel42.js:361 lib/thresholdPanel.js:364
 msgid "No Battery detected!"
-msgstr "Keine Batterie erkannt!"
+msgstr "Kein Akku erkannt!"
 
 #. TRANSLATORS: Keep translation short if possible. Maximum  34 characters can be displayed here
 #: lib/thresholdPanel42.js:367
@@ -269,7 +272,7 @@ msgstr "Batterielademodus"
 #. TRANSLATORS: Keep translation short if possible. Maximum  21 characters can be displayed here
 #: lib/thresholdPanel.js:354
 msgid "Battery Uninstalled"
-msgstr "Batterie deinstalliert"
+msgstr "Akku entfernt"
 
 #. TRANSLATORS: Keep translation short if possible. Maximum  34 characters can be displayed here
 #: lib/thresholdPanel.js:384
@@ -356,7 +359,7 @@ msgid ""
 "switch to <b>Symbols Only</b> and this option will be disabled."
 msgstr ""
 "Wählen Sie den Symboltyp für Anzeige und Menü aus.\n"
-"Wenn in den Schwellenwerteinstellungen der Modus <b>Anpassen</b> ausgewählt "
+"Wenn in den Schwellenwerteinstellungen der Modus <b>Angepasst</b> ausgewählt "
 "ist, wechselt der Symboltyp zu <b>Nur Symbole</b> und diese Option wird "
 "deaktiviert."
 
@@ -370,7 +373,7 @@ msgstr "Entfernen"
 
 #: preferences/general.js:178
 msgid "Install"
-msgstr "Install"
+msgstr "Installieren"
 
 #: preferences/general.js:181
 msgid "Update"
@@ -411,7 +414,7 @@ msgstr "<i>Akzeptierter Wert: %d bis %d</i>"
 
 #: ui/about.ui:5
 msgid "About"
-msgstr "Über"
+msgstr "Info"
 
 #: ui/about.ui:75
 msgid "Read me"
@@ -427,7 +430,7 @@ msgstr "Übersetzungen"
 
 #: ui/about.ui:136
 msgid "View sources on Github"
-msgstr "Quellcode anzeigen"
+msgstr "Quellcode auf GitHub anzeigen"
 
 #: ui/about.ui:153 ui/about.ui:271
 msgid "Legal"
@@ -632,11 +635,11 @@ msgstr ""
 
 #: ui/thresholdPrimary.ui:21 ui/thresholdSecondary.ui:21
 msgid "Customize"
-msgstr "Anpassen"
+msgstr "Angepasst"
 
 #: ui/thresholdPrimary.ui:27 ui/thresholdSecondary.ui:27
 msgid "Default"
-msgstr "Standard"
+msgstr "Voreinstellung"
 
 #: ui/thresholdPrimary.ui:47 ui/thresholdSecondary.ui:47
 msgid "Apply"


### PR DESCRIPTION
I tried to follow & apply some guidelines and standardized translations from GNOME & Ubuntu:
- https://wiki.gnome.org/de/UebersetzungsRichtlinien
- https://wiki.gnome.org/de(2f)StandardUebersetzungen.html
- https://wiki.ubuntu.com/UbuntuGermanTranslators/Standard%C3%BCbersetzungen

Major changes:
* use "Akku" for the physical Battery and "Batterie*" for the related settings
* translate "to set" with "festlegen" instead of "feststellen"/"setzen"

Note: see #138 for same changes in GNOME45 branch.