### PR TITLE
Add support for Linuwu-Sense (Acer Nitro)

### DIFF
--- a/devices/AcerNitro.js
+++ b/devices/AcerNitro.js
@@ -1,0 +1,97 @@
+'use strict';
+/* Acer Nitro Laptops using:
+   - https://github.com/0x7375646F/Linuwu-Sense (original driver) 
+   - https://github.com/PXDiv/Div-Linuwu-Sense  (fork) */
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import * as Helper from '../lib/helper.js';
+
+const {exitCode, fileExists, readFileInt, runCommandCtl} = Helper;
+
+const ACERNITRO_PATH = '/sys/module/linuwu_sense/drivers/platform:acer-wmi/acer-wmi/nitro_sense/battery_limiter';
+
+export const AcerNitroSingleBattery = GObject.registerClass({
+    Signals: {'threshold-applied': {param_types: [GObject.TYPE_STRING]}},
+}, class AcerNitroSingleBattery extends GObject.Object {
+    constructor(settings) {
+        super();
+        this.name = 'AcerNitro';
+        this.type = 40;
+        this.deviceNeedRootPermission = true;
+        this.deviceHaveDualBattery = false;
+        this.deviceHaveStartThreshold = false;
+        this.deviceHaveVariableThreshold = false;
+        this.deviceHaveBalancedMode = false;
+        this.deviceHaveAdaptiveMode = false;
+        this.deviceHaveExpressMode = false;
+        this.deviceUsesModeNotValue = false;
+        this.iconForFullCapMode = '100';
+        this.iconForMaxLifeMode = '080';
+
+        this._settings = settings;
+        this.ctlPath = null;
+    }
+
+    isAvailable() {
+        if (!fileExists(ACERNITRO_PATH))
+            return false;
+        return true;
+    }
+
+    async setThresholdLimit(chargingMode) {
+        if (chargingMode === 'ful')
+            this._healthMode = 0;
+        else if (chargingMode === 'max')
+            this._healthMode = 1;
+
+        if (this._verifyThreshold())
+            return exitCode.SUCCESS;
+
+        const [status] = await runCommandCtl(this.ctlPath, 'ACERNITRO', `${this._healthMode}`);
+        if (status === exitCode.ERROR) {
+            this.emit('threshold-applied', 'error');
+            return exitCode.ERROR;
+        } else if (status === exitCode.TIMEOUT) {
+            this.emit('threshold-applied', 'timeout');
+            return exitCode.ERROR;
+        }
+
+        if (this._verifyThreshold())
+            return exitCode.SUCCESS;
+
+        if (this._delayReadTimeoutId)
+            GLib.source_remove(this._delayReadTimeoutId);
+        this._delayReadTimeoutId = null;
+
+        await new Promise(resolve => {
+            this._delayReadTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, () => {
+                resolve();
+                this._delayReadTimeoutId = null;
+                return GLib.SOURCE_REMOVE;
+            });
+        });
+
+        if (this._verifyThreshold())
+            return exitCode.SUCCESS;
+
+        this.emit('threshold-applied', 'not-updated');
+        return exitCode.ERROR;
+    }
+
+    _verifyThreshold() {
+        const healthMode = readFileInt(ACERNITRO_PATH);
+        this.endLimitValue = healthMode === 1 ? 80 : 100;
+        if (this._healthMode === healthMode) {
+            this.emit('threshold-applied', 'success');
+            return true;
+        }
+        return false;
+    }
+
+    destroy() {
+        if (this._delayReadTimeoutId)
+            GLib.source_remove(this._delayReadTimeoutId);
+        this._delayReadTimeoutId = null;
+    }
+});
+

--- a/lib/deviceList.js
+++ b/lib/deviceList.js
@@ -25,6 +25,7 @@ import * as Fujitsu from '../devices/Fujitsu.js';
 import * as Chromebook from '../devices/Chromebook.js';
 import * as GalaxyBook from '../devices/GalaxyBook.js';
 import * as Acer2 from '../devices/Acer2.js';
+import * as AcerNitro from '../devices/AcerNitro.js';
 
 export const deviceArray = [
     Asus.AsusSingleBatteryBAT0,                     // 1
@@ -66,4 +67,5 @@ export const deviceArray = [
     Chromebook.ChromebookSingleBatteryV2,           // 37
     GalaxyBook.GalaxyBookSingleBatteryBAT1,         // 38
     Acer2.Acer2SingleBattery,                       // 39
+    AcerNitro.AcerNitroSingleBattery,               // 40
 ];

--- a/resources/batteryhealthchargingctl
+++ b/resources/batteryhealthchargingctl
@@ -16,6 +16,7 @@ HUAWEI_PATH='/sys/devices/platform/huawei-wmi/charge_control_thresholds'
 SAMSUNG_PATH='/sys/devices/platform/samsung/battery_life_extender'
 ACER_PATH='/sys/bus/wmi/drivers/acer-wmi-battery/health_mode'
 ACER2_PATH='/sys/devices/platform/acer_battery_wmi/acer_battery/health_mode'
+ACERNITRO_PATH='/sys/module/linuwu_sense/drivers/platform:acer-wmi/acer-wmi/nitro_sense/battery_limiter'
 BATC_END_PATH='/sys/class/power_supply/BATC/charge_control_end_threshold'
 BATT_END_PATH='/sys/class/power_supply/BATT/charge_control_end_threshold'
 TP_BAT0_END='/sys/devices/platform/smapi/BAT0/stop_charge_thresh'
@@ -202,6 +203,10 @@ case "$TOOLCMD" in
         ;;
     ACER2)
         echo "$ARG1" >"$ACER2_PATH" &&
+            exit "$EXIT_SUCCESS" || exit "$EXIT_ERROR"
+        ;;
+    ACERNITRO)
+        echo "$ARG1" >"$ACERNITRO_PATH" &&
             exit "$EXIT_SUCCESS" || exit "$EXIT_ERROR"
         ;;
     PANASONIC)


### PR DESCRIPTION
Added Support for a new kernel driver that supports Acer Nitro devices:

- https://github.com/0x7375646F/Linuwu-Sense (original driver) 
- https://github.com/PXDiv/Div-Linuwu-Sense  (fork) 

These drivers support many features besides battery health, and the last one has a nice installer that probably makes things much easier for Linux newbies.

Tested on Arch/GNOME 48/Wayland/Acer Nitro v15

PS: I did not bump the version, I thought you may want to check something first. If you prefer I can add a commit with it too, of course.


While I am here, if you are OK with it, I can:

- Submit a PR for the same driver for Predator devices, but I cannot test it since I do not have such device. It should be straight forward (the sys path contains `predator_sense` instead of `nitro_sense`), and even if it does not work it should be harmless AFAIK. Your call.
- Also submit a PR for de documentation website with the new drivers and the other one for Acer2.js that is missing.

Last but not least, thank you a lot for the nice extension. Much appreciated!

Regards