### PR TITLE
Add support for Linuwu-Sense (Acer Predator)

### DIFF
--- a/devices/AcerPredator.js
+++ b/devices/AcerPredator.js
@@ -1,0 +1,97 @@
+'use strict';
+/* Acer Predator Laptops using:
+   - https://github.com/0x7375646F/Linuwu-Sense (original driver) 
+   - https://github.com/PXDiv/Div-Linuwu-Sense  (fork) */
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import * as Helper from '../lib/helper.js';
+
+const {exitCode, fileExists, readFileInt, runCommandCtl} = Helper;
+
+const ACERPREDATOR_PATH = '/sys/module/linuwu_sense/drivers/platform:acer-wmi/acer-wmi/predator_sense/battery_limiter';
+
+export const AcerPredatorSingleBattery = GObject.registerClass({
+    Signals: {'threshold-applied': {param_types: [GObject.TYPE_STRING]}},
+}, class AcerPredatorSingleBattery extends GObject.Object {
+    constructor(settings) {
+        super();
+        this.name = 'AcerPredator';
+        this.type = 41;
+        this.deviceNeedRootPermission = true;
+        this.deviceHaveDualBattery = false;
+        this.deviceHaveStartThreshold = false;
+        this.deviceHaveVariableThreshold = false;
+        this.deviceHaveBalancedMode = false;
+        this.deviceHaveAdaptiveMode = false;
+        this.deviceHaveExpressMode = false;
+        this.deviceUsesModeNotValue = false;
+        this.iconForFullCapMode = '100';
+        this.iconForMaxLifeMode = '080';
+
+        this._settings = settings;
+        this.ctlPath = null;
+    }
+
+    isAvailable() {
+        if (!fileExists(ACERPREDATOR_PATH))
+            return false;
+        return true;
+    }
+
+    async setThresholdLimit(chargingMode) {
+        if (chargingMode === 'ful')
+            this._healthMode = 0;
+        else if (chargingMode === 'max')
+            this._healthMode = 1;
+
+        if (this._verifyThreshold())
+            return exitCode.SUCCESS;
+
+        const [status] = await runCommandCtl(this.ctlPath, 'ACERPREDATOR', `${this._healthMode}`);
+        if (status === exitCode.ERROR) {
+            this.emit('threshold-applied', 'error');
+            return exitCode.ERROR;
+        } else if (status === exitCode.TIMEOUT) {
+            this.emit('threshold-applied', 'timeout');
+            return exitCode.ERROR;
+        }
+
+        if (this._verifyThreshold())
+            return exitCode.SUCCESS;
+
+        if (this._delayReadTimeoutId)
+            GLib.source_remove(this._delayReadTimeoutId);
+        this._delayReadTimeoutId = null;
+
+        await new Promise(resolve => {
+            this._delayReadTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, () => {
+                resolve();
+                this._delayReadTimeoutId = null;
+                return GLib.SOURCE_REMOVE;
+            });
+        });
+
+        if (this._verifyThreshold())
+            return exitCode.SUCCESS;
+
+        this.emit('threshold-applied', 'not-updated');
+        return exitCode.ERROR;
+    }
+
+    _verifyThreshold() {
+        const healthMode = readFileInt(ACERPREDATOR_PATH);
+        this.endLimitValue = healthMode === 1 ? 80 : 100;
+        if (this._healthMode === healthMode) {
+            this.emit('threshold-applied', 'success');
+            return true;
+        }
+        return false;
+    }
+
+    destroy() {
+        if (this._delayReadTimeoutId)
+            GLib.source_remove(this._delayReadTimeoutId);
+        this._delayReadTimeoutId = null;
+    }
+});
+

--- a/lib/deviceList.js
+++ b/lib/deviceList.js
@@ -26,6 +26,7 @@ import * as Chromebook from '../devices/Chromebook.js';
 import * as GalaxyBook from '../devices/GalaxyBook.js';
 import * as Acer2 from '../devices/Acer2.js';
 import * as AcerNitro from '../devices/AcerNitro.js';
+import * as AcerPredator from '../devices/AcerPredator.js';
 
 export const deviceArray = [
     Asus.AsusSingleBatteryBAT0,                     // 1
@@ -68,4 +69,5 @@ export const deviceArray = [
     GalaxyBook.GalaxyBookSingleBatteryBAT1,         // 38
     Acer2.Acer2SingleBattery,                       // 39
     AcerNitro.AcerNitroSingleBattery,               // 40
+    AcerPredator.AcerPredatorSingleBattery,         // 41
 ];

--- a/resources/batteryhealthchargingctl
+++ b/resources/batteryhealthchargingctl
@@ -17,6 +17,7 @@ SAMSUNG_PATH='/sys/devices/platform/samsung/battery_life_extender'
 ACER_PATH='/sys/bus/wmi/drivers/acer-wmi-battery/health_mode'
 ACER2_PATH='/sys/devices/platform/acer_battery_wmi/acer_battery/health_mode'
 ACERNITRO_PATH='/sys/module/linuwu_sense/drivers/platform:acer-wmi/acer-wmi/nitro_sense/battery_limiter'
+ACERPREDATOR_PATH='/sys/module/linuwu_sense/drivers/platform:acer-wmi/acer-wmi/predator_sense/battery_limiter'
 BATC_END_PATH='/sys/class/power_supply/BATC/charge_control_end_threshold'
 BATT_END_PATH='/sys/class/power_supply/BATT/charge_control_end_threshold'
 TP_BAT0_END='/sys/devices/platform/smapi/BAT0/stop_charge_thresh'
@@ -207,6 +208,10 @@ case "$TOOLCMD" in
         ;;
     ACERNITRO)
         echo "$ARG1" >"$ACERNITRO_PATH" &&
+            exit "$EXIT_SUCCESS" || exit "$EXIT_ERROR"
+        ;;
+    ACERPREDATOR)
+        echo "$ARG1" >"$ACERPREDATOR_PATH" &&
             exit "$EXIT_SUCCESS" || exit "$EXIT_ERROR"
         ;;
     PANASONIC)


### PR DESCRIPTION
** **Attention: Not tested** **

Unfortunately I do not have access to an Acer Predator to test, but AFAIK the support *should* be straightforward and harmless, only change in the path is `nitro_sense` -> `predator_sense`.

Just as a reminder, the doc page probably needs to be updated to include the new driver options:
https://maniacx.github.io/Battery-Health-Charging/device-compatibility/acer

Thanks again.

PS: Sorry for the close/reopen mess, I forgot to sync the repo before submitting the PR.

Regards