### PR TITLE
installer: canonicalize TOOL_OUT so polkit rule matches on Fedora Atomic

### DIFF
--- a/resources/batteryhealthchargingctl
+++ b/resources/batteryhealthchargingctl
@@ -77,7 +77,10 @@ function check_installation() {
     fi
 
     TOOL_IN="${EXTDIR}/${BHC_BASE}"
-    TOOL_OUT="${BHC_DIR}/${BHC_BASE}-${TOOL_USER}"
+    # Resolve symlinks so cmp against the installed rule matches the path that
+    # installer.sh baked in (canonicalized). On Fedora Atomic /usr/local is a
+    # symlink to /var/usrlocal; on traditional layouts this is a no-op.
+    TOOL_OUT="$(readlink -f -m "${BHC_DIR}/${BHC_BASE}-${TOOL_USER}")"
     RULE_OUT="${RULE_DIR}/10-${RULE_BASE}-${TOOL_USER}.rules"
     ACTION_ID="${RULE_BASE}.${TOOL_USER}"
     ACTION_OUT="/usr/share/polkit-1/actions/${ACTION_ID}.policy"

--- a/tool/installer.sh
+++ b/tool/installer.sh
@@ -100,7 +100,10 @@ if [[ "$(recent_polkit)" != "available" ]]; then
 fi
 TOOL_IN="${DIR}/../${RESOURCES_DIR}/$BHC_BASE"
 
-TOOL_OUT="${BHC_DIR}/${BHC_BASE}-${TOOL_USER}"
+# Resolve symlinks in BHC_DIR so the path baked into the polkit rule matches
+# the canonical path polkit sees at exec time. On Fedora Atomic /usr/local is
+# a symlink to /var/usrlocal; on traditional layouts this is a no-op.
+TOOL_OUT="$(readlink -f -m "${BHC_DIR}/${BHC_BASE}-${TOOL_USER}")"
 RULE_OUT="${RULE_DIR}/10-${RULE_BASE}-${TOOL_USER}.rules"
 ACTION_ID="${RULE_BASE}.${TOOL_USER}"
 ACTION_OUT="/usr/share/polkit-1/actions/${ACTION_ID}.policy"


### PR DESCRIPTION
Fixes #194.

  ## Problem

  On Fedora Atomic (Silverblue, Kinoite, etc.), `/usr/local` is a symlink to `/var/usrlocal`. The installer bakes the literal
  `/usr/local/bin/batteryhealthchargingctl-$USER` into the polkit rule, but pkexec canonicalizes the program path before evaluating rules — it sees
  `/var/usrlocal/bin/...`, which does not match. Authorization fails, and users are prompted for a password on every charging-mode change.

  ## Fix

  Wrap `TOOL_OUT` with `readlink -f -m` in `tool/installer.sh` and in `check_installation` inside `resources/batteryhealthchargingctl`, so the
  canonical path is what gets written into the rule and what `cmp` checks against on subsequent runs.

  On traditional layouts (Ubuntu, Debian, Arch, Fedora Workstation, etc.) `readlink -f -m` is a no-op, so the rule contents and runtime behavior are
  unchanged. The patch is in shared polkit plumbing, so it is independent of laptop vendor/model.

  ## Test

  Verified on Fedora Silverblue 44 / GNOME 45:

  - Generated rule contains `program === "/var/usrlocal/bin/..."` (canonical path).
  - `pkexec ... CHECKINSTALLATION` returns 0 with no auth dialog.
  - Quick-settings tile toggles (Full Capacity / Balanced / Max Lifespan) apply silently, no password prompts.
  - `readlink -f -m` confirmed as a no-op on a symlink-free path (regression check for traditional layouts).