### PR TITLE
Add valid path available in homebrew

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -75,6 +75,8 @@ export function findValidProgramInPath(program) {
         '/run/wrapper/bin/',
         '/run/current-system/sw/bin/',
         '/etc/profiles/per-user/',
+        "/home/linuxbrew/.linuxbrew/bin/",
+        "/home/linuxbrew/.linuxbrew/sbin/",
     ];
     const path = GLib.find_program_in_path(program);
     if (path === null)

--- a/resources/batteryhealthchargingctl
+++ b/resources/batteryhealthchargingctl
@@ -152,6 +152,9 @@ function validate_path() {
         "/run/current-system/sw/bin/"
         "/nix/store/"
         "/etc/profiles/per-user/"
+        "/home/linuxbrew/.linuxbrew/bin/",
+        "/home/linuxbrew/.linuxbrew/sbin/"
+
     )
     for BASEPATH in "${VALIDPATHS[@]}"; do
         if [[ "$TOOLPATH" == "${BASEPATH}"* && "$TOOLPATH" == *"$TOOLNAME" ]]; then


### PR DESCRIPTION
When using Bluefin the "official" way of installing `framework_tools` is homebrew...